### PR TITLE
Bumps SwiftyJSON dependency version to match the version Kitura uses

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ let package = Package(
   name: "Mustache",
   dependencies: [
     //TODO make this test dependency once issue https://bugs.swift.org/browse/SR-883 is resolved
-      .Package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", majorVersion: 16, minor: 0)
+      .Package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", majorVersion: 17)
   ],
   exclude: ["Tests/Carthage", "Tests/vendor", "Tests/Info.plist"]
 )


### PR DESCRIPTION
Fixes `swift build` infinity loop when building projects with `Kitura` (requires version 17) and `GRMustache.swift` (required version 16.0).