### PR TITLE
Update for Swift 4 MatchingOptions rename

### DIFF
--- a/Sources/FoundationAdapterLinux.swift
+++ b/Sources/FoundationAdapterLinux.swift
@@ -23,7 +23,12 @@ class FoundationAdapter: FoundationAdapterProtocol {
     #else
         typealias RegularExpression = Foundation.RegularExpression
     #endif
-    typealias NSMatchingOptions = Foundation.NSMatchingOptions
+
+    #if swift(>=3.2)
+        typealias NSMatchingOptions = NSRegularExpression.MatchingOptions
+    #else
+        typealias NSMatchingOptions = Foundation.NSMatchingOptions
+    #endif
 
     /// Return the path component of a URL
     ///


### PR DESCRIPTION
This is required to compile on Linux with Swift 4.

Note, this is _not_ a Swift 4 refactoring of GRMustache.  It will currently compile in Swift 3 compatibility mode.